### PR TITLE
Order fails when it's a credit card order #39

### DIFF
--- a/server_scripts/services/dbUtils/setters.js
+++ b/server_scripts/services/dbUtils/setters.js
@@ -49,6 +49,10 @@ function updateOrInsertAllEntries(argsObj, cb) {
 	var idField = argsObj.idField;
 	var entries = argsObj.entries;
 
+	entries = entries.filter(function( element ) {
+	   return element;
+	});
+	
 	async.map(entries, function (entry, cb) {
 		if (_.isObject(entry)) {
 			// We're being given the object as a whole


### PR DESCRIPTION
This issue indeed is happening on certain accounts. As in issue #27, error is caused by a null value being processed by updateOrInsertAllEntries() function which in turn result in an error. However, I'm still trying to figure out how the null value gets there in the first place. 
In order to reduce to the minimum the likelihood of having errors after successful payments, I check for unwanted values in entries that updateOrInsertAllEntries() takes as an argument. This fixes the orders issue on sdaigle2@gmail.com's account and prevents similar cases for other users. 
